### PR TITLE
Fix Neuralynx Typo

### DIFF
--- a/ecephys_sorting.json
+++ b/ecephys_sorting.json
@@ -120,7 +120,7 @@
         "NWB GUIDE": false
     },
     {
-        "Format": "Nerualynx",
+        "Format": "Neuralynx",
         "Suffixes": null,
         "Example Data": false,
         "SpikeInterface - Extractor": false,


### PR DESCRIPTION
Fixes a basic typo. May want to double-check the rest of the entries.