### PR TITLE
Mark TDT format as supported by NWB GUIDE

### DIFF
--- a/src/assets/table_data/ecephys_recording.json
+++ b/src/assets/table_data/ecephys_recording.json
@@ -580,6 +580,6 @@
         "SpikeInterface - Tests": true,
         "NeuroConv - Interface": true,
         "NeuroConv - Tests": true,
-        "NWB GUIDE": false
+        "NWB GUIDE": true
     }
 ]


### PR DESCRIPTION
## Summary
- Updated the ecephys recording table to mark TDT format as supported by NWB GUIDE

NWB GUIDE supports converting ecephys data in TDT format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)